### PR TITLE
bigcrush: a script to run bigcrush in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ cd testu01
 ./bigcrushall.sh
 ```
 
-The TestU01 benchmark "big crush" (``bigcrush.sh``) might take days.
+The TestU01 benchmark "big crush" (``bigcrushall.sh``) might take days.
+A parallel version (``bigcrushallparallel.sh``) will test multiple generators at the same time, up to the number of detected CPU threads.
 
 #### Speed:
 It is interesting to assess running speed as well. This can be done quickly:

--- a/testu01/bigcrushall.sh
+++ b/testu01/bigcrushall.sh
@@ -3,7 +3,7 @@
 make -s
 parent=$(dirname "$0")
 
-declare -a commands=('testsplitmix64 -H' 'testsplitmix64' 'testpcg32' 'testpcg64 -H' 'testpcg64' 'testxoroshiro128plus -H' 'testxoroshiro128plus' 'testxorshift128plus -H' 'testxorshift128plus' 'testlehmer64' 'testlehmer64 -H' 'testaesctr'  'testxorshift32' 'testmersennetwister' 'testxorshift1024star' 'testxorshift1024star -H' );
+. "$parent/testlist.sh"
 for t in "${commands[@]}"; do
    $parent/bigcrush.sh $t 
 done # for t in "${commands[@]}"; do

--- a/testu01/bigcrushallparallel.sh
+++ b/testu01/bigcrushallparallel.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Original script by Daniel Lemire <lemire@gmail.com>
+# Parallel version by Jeff Epler <jepler@gmail.com>
+
+make -s
+parent=$(dirname "$0")
+
+. "$parent/testlist.sh"
+printf "$parent/bigcrush.sh %s\\0" "${commands[@]}" | xargs -0 -n1 -P`getconf _NPROCESSORS_ONLN` sh -c

--- a/testu01/testlist.sh
+++ b/testu01/testlist.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Normally this script is executed in the context of another script,
+# with the "." command.
+declare -a commands=('testsplitmix64 -H' 'testsplitmix64' 'testpcg32' 'testpcg64 -H' 'testpcg64' 'testxoroshiro128plus -H' 'testxoroshiro128plus' 'testxorshift128plus -H' 'testxorshift128plus' 'testlehmer64' 'testlehmer64 -H' 'testaesctr'  'testxorshift32' 'testmersennetwister' 'testxorshift1024star' 'testxorshift1024star -H' );
+


### PR DESCRIPTION
Since most systems have lots of parallelism available, this is
likely to make a bigcrushall run complete in much less time
than the "days" threatened by README.md.

No additional bashisms are used.

The printf(1) usage should be POSIX compliant.

While getconf(1) is portable, the getconf(1) usage is not portable,
because POSIX does not sysconf does not define _SC_NPROCESSORS_ONLN.
However, GNU (Linux), FreeBSD, NetBSD, OpenBSD, and MacOS all seem to.

While POSIX doesn't seem to define xargs' -P or -0 flags, in
practice GNU (Linux), FreeBSD, NetBSD, OpenBSD, and MacOS all seem
to.

If it's judged to be portable enough, then perhaps this should
replace the bigcrushall.sh script, rather than be added alongside
it.

References consulted:

Portability of getconf, printf, xargs in general:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/getconf.html
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/xargs.html

Widespread availablity of getconf _SC_NPROCESSORS_ONLN:
http://man7.org/linux/man-pages/man3/sysconf.3.html
http://netbsd.gw.com/cgi-bin/man-cgi?sysconf++NetBSD-current
https://man.openbsd.org/sysconf.3
https://www.freebsd.org/cgi/man.cgi?sysconf
https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man3/sysconf.3.html

Widespread availablity of xargs -P, -0 as extensions to POSIX:
http://man7.org/linux/man-pages/man1/xargs.1.html
https://www.freebsd.org/cgi/man.cgi?xargs
http://netbsd.gw.com/cgi-bin/man-cgi?xargs++NetBSD-current
https://man.openbsd.org/xargs.1
https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/xargs.1.html