### PR TITLE
Fix to splitmix_stateless. The current version gives a result of zero…

### DIFF
--- a/source/splitmix64.h
+++ b/source/splitmix64.h
@@ -53,7 +53,7 @@ static inline uint32_t splitmix64_cast32(void) {
 
 // same as splitmix64, but does not change the state, designed by D. Lemire
 static inline uint64_t splitmix64_stateless(uint64_t index) {
-  uint64_t z = (index * UINT64_C(0x9E3779B97F4A7C15));
+  uint64_t z = (index + UINT64_C(0x9E3779B97F4A7C15));
   z = (z ^ (z >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
   z = (z ^ (z >> 27)) * UINT64_C(0x94D049BB133111EB);
   return z ^ (z >> 31);


### PR DESCRIPTION
Fix to splitmix_stateless. The current version gives a result of zero for seed zero.