### PR TITLE
Add wyrand (upadted wyhash variant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Note  that the speed tests assume a recent x64 processor (e.g., they would not w
 - rand is whatever random number number generator your C standard library provides. It is a useful point of reference when assessing speed.
 - lehmer64 is a simple (but fast) Multiplicative Linear Congruential Generator
 - aesctr is a random number generator based on the AES cipher (contributed by Samuel Neves)
-- wyhash is random number generator based on the MUM hashing function
+- wyhash and wyrand is random number generator based on the MUM hashing function
 
 
 ## Methodology

--- a/practrand/Makefile
+++ b/practrand/Makefile
@@ -14,7 +14,7 @@ endif
 
 CFLAGS = -fPIC -std=c99 -O3 $(OPTIFLAG) -Wall -Wextra -Wshadow -Wno-implicit-function-declaration
 
-EXECUTABLES=testwidynski testlehmer64 testsplitmix64  testv8xorshift128plus testxoroshiro128plus testxorshift128plus testxorshift32 testpcg32 testpcg64 testaesctr testaesdragontamer testmitchellmoore testmersennetwister testxorshift-k4 testxorshift-k5 testxorshift1024star testxorshift1024plus testwyhash
+EXECUTABLES=testwidynski testlehmer64 testsplitmix64  testv8xorshift128plus testxoroshiro128plus testxorshift128plus testxorshift32 testpcg32 testpcg64 testaesctr testaesdragontamer testmitchellmoore testmersennetwister testxorshift-k4 testxorshift-k5 testxorshift1024star testxorshift1024plus testwyhash testwyrand
 
 HEADERS=include/main.h
 
@@ -35,6 +35,9 @@ testmitchellmoore: src/testmitchellmoore.c
 
 testwyhash: src/testwyhash.c
 	$(CC) $(CFLAGS) -o testwyhash src/testwyhash.c -I../source
+
+testwyrand: src/testwyrand.c
+	$(CC) $(CFLAGS) -o testwyrand src/testwyrand.c -I../source
 
 
 testmersennetwister: src/testmersennetwister.c

--- a/practrand/runtests.sh
+++ b/practrand/runtests.sh
@@ -6,7 +6,7 @@ NC='\033[0m' # No Color
 echo "Testing "$MEM " of data per run"
 echo "Note: running the tests longer could expose new failures."
 
-declare -a commands=('testmitchellmoore' 'testmersennetwister' 'testxorshift-k4' 'testxorshift-k5' 'testwidynski' 'testaesctr' 'testaesdragontamer'  'testv8xorshift128plus -H' 'testv8xorshift128plus' 'testxorshift128plus -H' 'testxorshift128plus' 'testxoroshiro128plus -H' 'testxoroshiro128plus' 'testpcg32' 'testpcg64 -H' 'testpcg64' 'testsplitmix64 -H' 'testsplitmix64' 'testxorshift32'  'testxorshift1024star' 'testxorshift1024star -H'  'testxorshift1024plus' 'testxorshift1024plus -H' 'testwyhash' 'testwyhash -H');
+declare -a commands=('testmitchellmoore' 'testmersennetwister' 'testxorshift-k4' 'testxorshift-k5' 'testwidynski' 'testaesctr' 'testaesdragontamer'  'testv8xorshift128plus -H' 'testv8xorshift128plus' 'testxorshift128plus -H' 'testxorshift128plus' 'testxoroshiro128plus -H' 'testxoroshiro128plus' 'testpcg32' 'testpcg64 -H' 'testpcg64' 'testsplitmix64 -H' 'testsplitmix64' 'testxorshift32'  'testxorshift1024star' 'testxorshift1024star -H'  'testxorshift1024plus' 'testxorshift1024plus -H' 'testwyhash' 'testwyhash -H' 'testwyrand' 'testwyrand -H');
 for t in "${commands[@]}"; do
      wf=$(echo $t | sed 's/ //g')
      filelog=$wf.log

--- a/practrand/src/testwyrand.c
+++ b/practrand/src/testwyrand.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <getopt.h>
+
+#include "wyrand.h"
+
+#define buffer_size 512
+int main(int argc, char **argv) {
+  int c;
+  while ((c = getopt(argc, argv, "")) != -1)
+    switch (c) {
+    default:
+      abort();
+    }
+  uint64_t seedvalue = 12345678;
+  wyrand_seed(seedvalue);
+  uint32_t buffer[buffer_size];
+  while (1) {
+      for (int k = 0; k < buffer_size; k++)
+        buffer[k] = wyrand();
+      fwrite((void *)buffer, sizeof(buffer), 1, stdout);
+  }
+}

--- a/source/wyrand.h
+++ b/source/wyrand.h
@@ -1,0 +1,21 @@
+// adapted to this project by D. Lemire, from https://github.com/wangyi-fudan/wyhash/blob/master/wyhash.h
+// This uses mum hashing.
+#include <stdint.h>
+// state for wyrand
+uint64_t wyrand_x; /* The state can be seeded with any value. */
+
+// call wyrand_seed before calling wyrand
+static inline void wyrand_seed(uint64_t seed) { wyrand_x = seed; }
+
+static inline uint64_t wyrand_stateless(uint64_t *s) {
+  *s += UINT64_C(0xa0761d6478bd642f);
+  __uint128_t t = (__uint128_t)*s * (*s ^ UINT64_C(0xe7037ed1a0b428db));
+  return (t >> 64) ^ t;
+}
+
+// returns random number, modifies wyrand_x
+static inline uint64_t wyrand(void) { return wyrand_stateless(&wyrand_x); }
+
+// returns the 32 least significant bits of a call to wyrand
+// this is a simple function call followed by a cast
+static inline uint32_t wyrand_cast32(void) { return (uint32_t)wyrand(); }

--- a/speed/src/rng.c
+++ b/speed/src/rng.c
@@ -21,6 +21,7 @@
 #include "widynski.h"
 #include "aesdragontamer.h"
 #include "wyhash.h"
+#include "wyrand.h"
 
 
 #ifndef __x86_64__
@@ -40,10 +41,10 @@ const char *our32name[NUMBEROF32] = {
 
 #define NUMBEROF64 10
 rand64fnc our64[NUMBEROF64] = {aesdragontamer, aesctr,           lehmer64,   xorshift128plus,
-                               xoroshiro128plus, splitmix64, pcg64, xorshift1024star, xorshift1024plus, wyhash64};
+                               xoroshiro128plus, splitmix64, pcg64, xorshift1024star, xorshift1024plus, wyhash64, wyrand};
 const char *our64name[NUMBEROF64] = {"aesdragontamer","aesctr",          "lehmer64",
                                      "xorshift128plus", "xoroshiro128plus",
-                                     "splitmix64",      "pcg64", "xorshift1024star", "xorshift1024plus", "wyhash64"};
+                                     "splitmix64",      "pcg64", "xorshift1024star", "xorshift1024plus", "wyhash64", "wyrand"};
 
 void populate32(rand32fnc rand, uint32_t *answer, size_t size) {
   for (size_t i = size; i != 0; i--) {

--- a/testu01/Makefile
+++ b/testu01/Makefile
@@ -17,7 +17,7 @@ CFLAGS = -fPIC -std=c99 -O3 $(OPTIFLAG) -Wall -Wextra -Wshadow -Wno-implicit-fun
 LIBS=build/lib/libmylib.a build/lib/libprobdist.a build/lib/libtestu01.a
 LIBSCMD= build/lib/libtestu01.a  build/lib/libprobdist.a build/lib/libmylib.a  -lm
 LIBTARGET=build/lib/libmylib.a
-EXECUTABLES=testaesdragontamer testmersennetwister testlehmer64 testsplitmix64 testxoroshiro128plus testv8xorshift128plus testxorshift128plus testxorshift32 testpcg32 testpcg64 testaesctr testxorshift1024star testxorshift1024plus testwyhash
+EXECUTABLES=testaesdragontamer testmersennetwister testlehmer64 testsplitmix64 testxoroshiro128plus testv8xorshift128plus testxorshift128plus testxorshift32 testpcg32 testpcg64 testaesctr testxorshift1024star testxorshift1024plus testwyhash testwyrand
 
 HEADERS=include/main.h
 
@@ -62,6 +62,9 @@ testxorshift128plus: $(LIBTARGET) $(HEADERS)
 
 testwyhash: $(LIBTARGET) $(HEADERS)
 	$(CC) $(CFLAGS) -o testwyhash src/testwyhash.c $(LIBSCMD) -I../source -Ibuild/include/ -Iinclude
+
+testwyrand: $(LIBTARGET) $(HEADERS)
+	$(CC) $(CFLAGS) -o testwyrand src/testwyrand.c $(LIBSCMD) -I../source -Ibuild/include/ -Iinclude
 
 
 testv8xorshift128plus: $(LIBTARGET) $(HEADERS)

--- a/testu01/src/testwyrand.c
+++ b/testu01/src/testwyrand.c
@@ -1,0 +1,9 @@
+#include "wyrand.h"
+
+static inline void thisrng_seed(uint64_t seed) { wyrand_seed(seed); }
+
+static inline uint64_t thisrng() { return wyrand(); }
+
+const char *name = "wyrand";
+
+#include "main.h"

--- a/testu01/testlist.sh
+++ b/testu01/testlist.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Normally this script is executed in the context of another script,
 # with the "." command.
-declare -a commands=('testsplitmix64 -H' 'testsplitmix64' 'testpcg32' 'testpcg64 -H' 'testpcg64' 'testxoroshiro128plus -H' 'testxoroshiro128plus' 'testv8xorshift128plus -H' 'testv8xorshift128plus' 'testxorshift128plus -H' 'testxorshift128plus' 'testlehmer64' 'testlehmer64 -H' 'testaesctr'  'testxorshift32' 'testmersennetwister' 'testxorshift1024star' 'testxorshift1024star -H' 'testxorshift1024plus' 'testxorshift1024plus -H' 'testwyhash' 'testwyhash -H' );
+declare -a commands=('testsplitmix64 -H' 'testsplitmix64' 'testpcg32' 'testpcg64 -H' 'testpcg64' 'testxoroshiro128plus -H' 'testxoroshiro128plus' 'testv8xorshift128plus -H' 'testv8xorshift128plus' 'testxorshift128plus -H' 'testxorshift128plus' 'testlehmer64' 'testlehmer64 -H' 'testaesctr'  'testxorshift32' 'testmersennetwister' 'testxorshift1024star' 'testxorshift1024star -H' 'testxorshift1024plus' 'testxorshift1024plus -H' 'testwyhash' 'testwyhash -H' 'testwyrand' 'testwyrand -H' );


### PR DESCRIPTION
Resolves issue #16.

As discussed in lemire/SwiftWyhash/issues/6

I *hope* this works 🤞, because I have just cloned every `wyhash`/`wyhash64` occurrence into `wyrand`…