### PR TITLE
Adjust use of splitmix64 when seeding other RNGs

### DIFF
--- a/source/aesdragontamer.h
+++ b/source/aesdragontamer.h
@@ -38,8 +38,8 @@ static inline void aesdragontamer_seed_r(aesdragontamer_state *state,
       _mm_set_epi8(0x2f, 0x2b, 0x29, 0x25, 0x1f, 0x1d, 0x17, 0x13, 0x11, 0x0D,
                    0x0B, 0x07, 0x05, 0x03, 0x02, 0x01);
   state->offset = 0;
-  state->state = _mm_set_epi64x(splitmix64_stateless(seed),
-                                splitmix64_stateless(seed + 1));
+  state->state = _mm_set_epi64x(splitmix64_stateless(seed, 0),
+                                splitmix64_stateless(seed, 1));
   aesdragontamer_tobuffer_r(state);
 }
 

--- a/source/lehmer64.h
+++ b/source/lehmer64.h
@@ -18,8 +18,8 @@ static __uint128_t g_lehmer64_state;
 */
 
 static inline void lehmer64_seed(uint64_t seed) {
-  g_lehmer64_state = (((__uint128_t)splitmix64_stateless(seed)) << 64) +
-                     splitmix64_stateless(seed + 1);
+  g_lehmer64_state = (((__uint128_t)splitmix64_stateless(seed, 0)) << 64) +
+                     splitmix64_stateless(seed, 1);
 }
 
 static inline uint64_t lehmer64() {

--- a/source/pcg32.h
+++ b/source/pcg32.h
@@ -19,10 +19,10 @@ static pcg32_random_t pcg32_global; // global state
 
 // call this once before calling pcg32_random_r
 static inline void pcg32_seed(uint64_t seed) {
-  pcg32_global.state = splitmix64_stateless(seed);
+  pcg32_global.state = splitmix64_r(&seed);
   // we pick a sequence at random
   pcg32_global.inc =
-      (splitmix64_stateless(seed + 1)) | 1; // making sure it is odd
+      (splitmix64_r(&seed)) | 1; // making sure it is odd
 }
 
 static inline uint32_t pcg32_random_r(pcg32_random_t *rng) {

--- a/source/pcg64.h
+++ b/source/pcg64.h
@@ -63,11 +63,11 @@ static pcg64_random_t pcg64_global; // global state
 
 // call this once before calling pcg64_random_r
 static inline void pcg64_seed(uint64_t seed) {
-  pcg128_t initstate = PCG_128BIT_CONSTANT(splitmix64_stateless(seed),
-                                           splitmix64_stateless(seed + 1));
+  pcg128_t initstate = PCG_128BIT_CONSTANT(splitmix64_stateless(seed, 0),
+                                           splitmix64_stateless(seed, 1));
   // we pick a sequence at random
-  pcg128_t initseq = PCG_128BIT_CONSTANT(splitmix64_stateless(seed + 2),
-                                         splitmix64_stateless(seed + 3));
+  pcg128_t initseq = PCG_128BIT_CONSTANT(splitmix64_stateless(seed, 2),
+                                         splitmix64_stateless(seed, 3));
   initseq |= 1; // should not be necessary, but let us be careful.
 
   pcg_setseq_128_srandom_r(&pcg64_global, initstate, initseq);

--- a/source/splitmix64.h
+++ b/source/splitmix64.h
@@ -36,28 +36,35 @@ uint64_t splitmix64_x; /* The state can be seeded with any value. */
 // call this one before calling splitmix64
 static inline void splitmix64_seed(uint64_t seed) { splitmix64_x = seed; }
 
-// returns random number, modifies splitmix64_x
+// floor( ( (1+sqrt(5))/2 ) * 2**64 MOD 2**64)
+#define GOLDEN_GAMMA UINT64_C(0x9E3779B97F4A7C15)
+
+// returns random number, modifies seed[0]
 // compared with D. Lemire against
 // http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8-b132/java/util/SplittableRandom.java#SplittableRandom.0gamma
-static inline uint64_t splitmix64(void) {
-  uint64_t z = (splitmix64_x += UINT64_C(0x9E3779B97F4A7C15));
+static inline uint64_t splitmix64_r(uint64_t *seed) {
+  uint64_t z = (*seed += GOLDEN_GAMMA);
+  // David Stafford's Mix13 for MurmurHash3's 64-bit finalizer
   z = (z ^ (z >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
   z = (z ^ (z >> 27)) * UINT64_C(0x94D049BB133111EB);
   return z ^ (z >> 31);
 }
 
+// returns random number, modifies splitmix64_x
+static inline uint64_t splitmix64(void) {
+    return splitmix64_r(&splitmix64_x);
+}
+
 // returns the 32 least significant bits of a call to splitmix64
-// this is a simple function call followed by a cast
+// this is a simple (inlined) function call followed by a cast
 static inline uint32_t splitmix64_cast32(void) {
   return (uint32_t)splitmix64();
 }
 
-// same as splitmix64, but does not change the state, designed by D. Lemire
-static inline uint64_t splitmix64_stateless(uint64_t index) {
-  uint64_t z = (index + UINT64_C(0x9E3779B97F4A7C15));
-  z = (z ^ (z >> 30)) * UINT64_C(0xBF58476D1CE4E5B9);
-  z = (z ^ (z >> 27)) * UINT64_C(0x94D049BB133111EB);
-  return z ^ (z >> 31);
+// returns the value of splitmix64 "offset" steps from seed
+static inline uint64_t splitmix64_stateless(uint64_t seed, uint64_t offset) {
+  seed += offset*GOLDEN_GAMMA;
+  return splitmix64_r(&seed);
 }
 
 #endif // SPLITMIX64_H

--- a/source/xoroshiro128plus.h
+++ b/source/xoroshiro128plus.h
@@ -34,8 +34,8 @@ static inline uint64_t rotl(const uint64_t x, int k) {
 
 // call this one before calling xoroshiro128plus
 static inline void xoroshiro128plus_seed(uint64_t seed) {
-  xoroshiro128plus_s[0] = splitmix64_stateless(seed);
-  xoroshiro128plus_s[1] = splitmix64_stateless(seed + 1);
+  xoroshiro128plus_s[0] = splitmix64_r(&seed);
+  xoroshiro128plus_s[1] = splitmix64_r(&seed);
 }
 
 // returns random number, modifies xoroshiro128plus_s

--- a/source/xorshift-k4.h
+++ b/source/xorshift-k4.h
@@ -11,10 +11,10 @@
 static uint32_t xorshift_k4_x, xorshift_k4_y, xorshift_k4_z, xorshift_k4_w;
 
 static inline void xorshift_k4_seed(uint64_t seed) {
-  xorshift_k4_x = splitmix64_stateless(seed);
-  xorshift_k4_y = splitmix64_stateless(seed + 1);
-  xorshift_k4_z = splitmix64_stateless(seed + 2);
-  xorshift_k4_w = splitmix64_stateless(seed + 3);
+  xorshift_k4_x = splitmix64_r(&seed);
+  xorshift_k4_y = splitmix64_r(&seed);
+  xorshift_k4_z = splitmix64_r(&seed);
+  xorshift_k4_w = splitmix64_r(&seed);
   return;
 }
 

--- a/source/xorshift-k5.h
+++ b/source/xorshift-k5.h
@@ -12,11 +12,11 @@ static uint32_t xorshift_k5_x, xorshift_k5_y, xorshift_k5_z, xorshift_k5_w,
     xorshift_k5_v;
 
 static inline void xorshift_k5_seed(uint64_t seed) {
-  xorshift_k5_x = splitmix64_stateless(seed);
-  xorshift_k5_y = splitmix64_stateless(seed + 1);
-  xorshift_k5_z = splitmix64_stateless(seed + 2);
-  xorshift_k5_w = splitmix64_stateless(seed + 3);
-  xorshift_k5_v = splitmix64_stateless(seed + 4);
+  xorshift_k5_x = splitmix64_r(&seed);
+  xorshift_k5_y = splitmix64_r(&seed);
+  xorshift_k5_z = splitmix64_r(&seed);
+  xorshift_k5_w = splitmix64_r(&seed);
+  xorshift_k5_v = splitmix64_r(&seed);
   return;
 }
 

--- a/source/xorshift1024plus.h
+++ b/source/xorshift1024plus.h
@@ -16,7 +16,7 @@ static int xorshift1024plus_p;
 static inline void xorshift1024plus_seed(uint64_t seed) {
   xorshift1024plus_p = 0;
   for (int k = 0; k < xorshift1024plus_size; k++)
-    xorshift1024plus_s[k] = splitmix64_stateless(seed + k);
+    xorshift1024plus_s[k] = splitmix64_r(&seed);
 }
 // returns random number, modifies xorshift1024plus_s and xorshift1024plus_p
 static inline uint64_t xorshift1024plus(void) {

--- a/source/xorshift1024star.h
+++ b/source/xorshift1024star.h
@@ -32,7 +32,7 @@ static int xorshift1024star_p;
 static inline void xorshift1024star_seed(uint64_t seed) {
   xorshift1024star_p = 0;
   for (int k = 0; k < xorshift1024star_size; k++)
-    xorshift1024star_s[k] = splitmix64_stateless(seed + k);
+    xorshift1024star_s[k] = splitmix64_r(&seed);
 }
 
 // returns random number, modifies xorshift1024star_s and xorshift1024star_p

--- a/source/xorshift128plus.h
+++ b/source/xorshift128plus.h
@@ -24,8 +24,8 @@ static inline void xorshift128plus_init(uint64_t key1, uint64_t key2,
 }
 
 static inline void xorshift128plus_seed(uint64_t seed) {
-  xorshift128plus_init(splitmix64_stateless(seed),
-                       splitmix64_stateless(seed + 1),
+  xorshift128plus_init(splitmix64_stateless(seed, 0),
+                       splitmix64_stateless(seed, 1),
                        &global_xorshift128plus_key);
 }
 

--- a/unit/src/v8equiv.c
+++ b/unit/src/v8equiv.c
@@ -36,8 +36,9 @@ bool are_equiv(xorshift128plus_key_t *key) {
 int main() {
   for(size_t seed = 0; seed < 1000000; seed++) {
     xorshift128plus_key_t key;
-    key.part1 = splitmix64_stateless(seed);
-    key.part2 = splitmix64_stateless(seed + 1);
+    uint64_t rng_seed[1] = {seed};
+    key.part1 = splitmix64_r(rng_seed);
+    key.part2 = splitmix64_r(rng_seed);
     if(!are_equiv(&key)) {
       printf("Bug!\n");
       return -1;


### PR DESCRIPTION
WRT: Issue https://github.com/lemire/testingRNG/issues/24

I have currently got two methods of updating the use of splitmix64, your state recalculation method (or "stateless") and the more usual method of providing a pointer to space for the RNG state. The first uses an additional argument to split the seed and the number of rounds to skip, the second uses the provided space to carry state between invocations.

I prefer the more usual `splitmix64_r` style, however, this would involve adding some temp variables to avoid C "undefined behavior" for several of the uses. Would you like me to do this or leave the changes as they are?

Also: I've merged the multiple copies of `splitmix64` into `splitmix64_r` which is then called by different wrappers. 

Also: As an aside I had to downgrade the build environment to Debian Stretch as later versions of Debian are `abort()`ing due to double free errors when I start Practrand.
